### PR TITLE
Remove `super._init()` from ScatterShaper's `_init()` function

### DIFF
--- a/addons/goshapes/ShatterShaper/ScatterShaper.gd
+++ b/addons/goshapes/ShatterShaper/ScatterShaper.gd
@@ -101,7 +101,6 @@ var watcher_noise := ResourceWatcher.new(emit_changed)
 			
 			
 func _init():
-	super._init()
 	if not scene_source:
 		scene_source = ScatterItem.new()
 	watcher_noise.watch(noise)


### PR DESCRIPTION
Closes #10 