### PR TITLE
make it possible to configure a path to either use round edges or not

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Alongside that, there's the Path Options which can be copied between shapes.
  - **Twist** will allow you to bend the path in weird and wonderful ways for shapes like corkscrews and vertical spirals.
  - **Line** will cause the shape to extrude along the path instead of filling the path. This is useful for footpaths, roads and fences.
  - **Rounding** will round the edges of the shape by the desired distance
+ - **Round Edges** whether to round the edges of the shape or not
  - **Interpolate** affects the detail of the shape
  - **Points On Ground** will cause the points to align to the surface below them using Raycasting
  - **Offset Y** shifts the shape up or down

--- a/addons/goshapes/Goshape.gd
+++ b/addons/goshapes/Goshape.gd
@@ -296,7 +296,7 @@ func get_path_data(interpolate: int) -> PathData:
 	if path_options.line != 0:
 		path_data = PathUtils.path_to_outline(path_data, path_options.line)
 	if path_options.rounding > 0:
-		path_data = PathUtils.round_path(path_data, path_options.rounding, interpolate)
+		path_data = PathUtils.round_path(path_data, path_options.round_edges, path_options.rounding, interpolate)
 	path_data.curve = curve.duplicate()
 	if path_options.ground_placement_mask:
 		path_data.placement_mask = path_options.ground_placement_mask

--- a/addons/goshapes/base/PathOptions.gd
+++ b/addons/goshapes/base/PathOptions.gd
@@ -31,6 +31,13 @@ extends Resource
 		emit_changed()
 
 
+## Either rounds the edges of the path, or not
+@export var round_edges: bool = true:
+	set(value):
+		round_edges = value
+		emit_changed()
+
+
 ## Increases the resolution of path curve data
 @export_range(1, 4, 1) var interpolate: int = 1:
 	set(value):

--- a/addons/goshapes/utils/PathUtils.gd
+++ b/addons/goshapes/utils/PathUtils.gd
@@ -122,30 +122,34 @@ static func path_to_outline(path: PathData, width: float) -> PathData:
 	return PathData.new(path_points, path_ups)
 	
 
-static func round_path(path: PathData, round_dist: float, interpolate: int = 0) -> PathData:
+static func round_path(path: PathData, round_edges: bool, round_dist: float, interpolate: int = 0) -> PathData:
 	if interpolate < 1:
 		interpolate = 1
 	var iterations = interpolate + 1
 	var sub_dist = round_dist
 	var result = path
 	for i in range(iterations):
-		result = round_path_it(result, sub_dist)
+		result = round_path_it(result, round_edges, sub_dist)
 		sub_dist /= PI
 	return result
 	
 	
-static func round_path_it(path: PathData, round_dist: float) -> PathData:
+static func round_path_it(path: PathData, round_edges: bool, round_dist: float) -> PathData:
 	var point_count = path.points.size()
 	var points = PackedVector3Array()
 	points.resize(point_count * 2)
 	var ups = PackedVector3Array()
 	ups.resize(point_count * 2)
 	for i in range(point_count):
+		var is_edge  := i == 0 or i == point_count-1
+		var do_round := (not is_edge) or (is_edge and round_edges)
+		var rounding := round_dist * 0.5 if do_round else 0
+
 		var p = path.points[i]
 		var prev = path.points[i - 1 if i > 0 else point_count - 1]
 		var next = path.points[i + 1 if i < point_count - 1 else 0]
-		var a = move_point_towards(p, prev, round_dist * 0.5)
-		var b = move_point_towards(p, next, round_dist * 0.5)
+		var a = move_point_towards(p, prev, rounding)
+		var b = move_point_towards(p, next, rounding)
 		points.set(i * 2, a)
 		points.set(i * 2 + 1, b)
 		ups.set(i * 2, path.ups[i])


### PR DESCRIPTION
fixes #18 by adding the option to either round edges, or not.

see #18 for context, and the video below for results. 

_IMO having `set_edges=false` as a default makes more sense (at least for `*WallShaper`s) but that would be a breaking change, so I set the default to `true`._

 

https://github.com/user-attachments/assets/1b4e21ec-3cdf-4d47-8176-e5baeb5e4660

