### PR TITLE
add the option to use a placeholder mesh in the WallMeshShaper

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,19 @@ There are three cap shaper types: **Flat**, **Plane** and **Line**. Flat and Pla
 All Cap shapers take a material and render its UVs 1:1 in world space.
 
 ##### The WallShapers (generates a wall around the path, best used as part of a BlackShaper)
-There are two wall shaper types: **Bevel** and **Mesh**. Bevel will generate a straight wall and allows tapering and bevelling. **MeshWall** is the most useful, allowing you to **create custom geometry and wrap it to a wall**. There are some tricks to creating that geometry, that I go into below (see Making Mesh Walls).
+There are two wall shaper types: **Bevel** and **Mesh**. Bevel will generate a straight wall and allows tapering and bevelling. **MeshWall** is the most useful, allowing you to **create custom geometry and wrap it to a wall**. There are some tricks to creating that geometry, that I go into below (see Making Mesh Walls). You can set a simpler placeholder mesh which can be toggled in the editor for performance reasons while editing. 
 
 ![image](https://user-images.githubusercontent.com/386025/174335860-a66f9344-9209-487b-b2b1-fdd604b1de5c.png)
 
+##### Making Mesh Walls
+For the mesh that will be wrapped around the shape, you should use a mesh that;
+
+* start from origin (0,0,0)
+* spans the X axis
+* has sufficient subdivisions to make it easier to wrap around the shape
+
+see the included cliff.obj for an example of a mesh that can be wrapped around a shape.
+  
 #### The ScatterShaper: Useful for randomly placing objects within an area
 ![image](https://user-images.githubusercontent.com/386025/174336335-7daa2bd6-2e64-4426-88f6-4da5b4f35cee.png)
 

--- a/addons/goshapes/MeshShaper/Shapers/WallMeshShaper.gd
+++ b/addons/goshapes/MeshShaper/Shapers/WallMeshShaper.gd
@@ -10,6 +10,20 @@ extends WallShaper
 			mesh = value
 			emit_changed()
 	
+## An optional placeholder mesh to use while editing
+@export var placeholder_mesh: Mesh: 
+	set(value):
+		if placeholder_mesh != value:
+			placeholder_mesh = value
+			emit_changed()
+	
+## Whether to use the placeholder mesh or the actual mesh
+@export var use_placeholder: bool = false: 
+	set(value):
+		if use_placeholder != value:
+			use_placeholder = value
+			emit_changed()
+	
 ## The scale to apply to each mesh segment	
 @export_range(0.1, 10.0, 0.1) var scale = 1.0:
 	set(value):
@@ -45,7 +59,7 @@ class WallMeshBuilder extends WallBuilder:
 		style = _style
 
 	func build_sets(path: PathData) -> Array[MeshSet]:
-		var ref_mesh = style.mesh as Mesh
+		var ref_mesh = (style.placeholder_mesh if style.use_placeholder else style.mesh) as Mesh
 		if not ref_mesh:
 			return []
 			

--- a/addons/goshapes/plugin.gd
+++ b/addons/goshapes/plugin.gd
@@ -106,6 +106,8 @@ func get_menuset(menuset: MenuSet):
 		["Add New BlockShape", self, "add_block"],
 		["Add New ScatterShape", self, "add_scatter"],
 		["Select All Blocks", self, "select_all_blocks"],
+		["Turn ON All Placeholder Meshes", self, "turn_on_placeholder_meshes"],
+		["Turn OFF All Placeholder Meshes", self, "turn_off_placeholder_meshes"],
 		["Turn %s Block Select" % ("OFF" if block_select else "ON"), self, "toggle_block_select"]
 	]
 	if menuset == MenuSet.BLOCK:
@@ -312,6 +314,35 @@ func select_all_blocks(parent: Node = null) -> void:
 	for i in range(parent.get_child_count()):
 		select_all_blocks(parent.get_child(i))
 		
+func turn_on_placeholder_meshes() -> void:
+	toggle_placeholder_meshes(true)
+	
+func turn_off_placeholder_meshes() -> void:
+	toggle_placeholder_meshes(false)
+	
+func toggle_placeholder_meshes(turn_on: bool, parent: Node = null) -> void:
+	if parent == null:
+		parent = get_tree().root
+	if parent is Goshape:
+		var goshape : Goshape = parent 
+		var wall_mesh_shaper: WallMeshShaper
+
+		if goshape.shaper is BlockShaper:
+			var block_shaper : BlockShaper = goshape.shaper
+			if block_shaper.wall_shaper is WallMeshShaper:
+				wall_mesh_shaper = block_shaper.wall_shaper as WallMeshShaper
+		elif goshape.shaper is WallMeshShaper:
+			wall_mesh_shaper = goshape.shaper as WallMeshShaper
+		
+		if wall_mesh_shaper and wall_mesh_shaper.placeholder_mesh:
+			if wall_mesh_shaper.use_placeholder != turn_on:
+				wall_mesh_shaper.use_placeholder = turn_on
+				goshape._build(proxy.runner)
+				#var builder := wall_mesh_shaper.get_builder()
+				#builder.build(goshape, goshape.get_path_data(goshape.path_options.interpolate))
+				
+	for i in range(parent.get_child_count()):
+		toggle_placeholder_meshes(turn_on, parent.get_child(i))
 		
 func copy_block_params(block: Goshape) -> void:
 	proxy.last_shaper = block.shaper


### PR DESCRIPTION
fixes #15 by adding the option to set a placeholder mesh, which can be toggled to be used while editing to greatly improve the performance and developer experience.

I also took the opportunity to address the point raised in #8 by copy-pasting (with formating) the information you provided in that issue (which I followed for great results btw).

See #15 for context
 
_OBS! the image for the `MeshWallShaper` editor block needs to be updated in the `README.md`, but it requires you to upload a new image to github_

* closes #8 
* closes #15

https://github.com/user-attachments/assets/5c3aeb30-914f-4031-9551-d11246e80791

