### PR TITLE
when adding a goshape, in _enter_tree, toggle on _edit_group 

### DIFF
--- a/addons/goshapes/Goshape.gd
+++ b/addons/goshapes/Goshape.gd
@@ -68,6 +68,7 @@ func _ready() -> void:
 
 func _enter_tree() -> void:
 	set_display_folded(true)
+	set_meta("_edit_group_", true)
 	
 	
 func _exit_tree() -> void:


### PR DESCRIPTION
This is to not make the children (meshes, collider, etc) of the `Goshape`'s selectable from the 3D scene viewer when a new node is added. I think this makes sense, since it's almost never the case that you want to select a child (since these are re-created over and over) when clicking a `Goshape`.